### PR TITLE
Fix s3-sync-action AWS_S3_ENDPOINT

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
         AWS_REGION: ${{ inputs.aws_region }}
         SOURCE_DIR: 'storybook-static'
-        AWS_S3_HOST: ${{ inputs.aws_s3_host }}
+        AWS_S3_ENDPOINT: ${{ inputs.aws_s3_host }}
         DEST_DIR: ${{ steps.preview.outputs.value }}
 
     - name: 'Comment on PR'


### PR DESCRIPTION
`jakejarvis/s3-sync-action` doesn't have an environment variable`AWS_S3_HOST`.
The correct env is `AWS_S3_ENDPOINT`.